### PR TITLE
Some updates & fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,17 @@ RUN apt-get -y -qq update \
 # install orientdb
 ENV ROOT /opt/downloads
 ENV ORIENT_URL http://www.orientdb.org/portal/function/portal/download/unknown@unknown.com
-ENV ORIENT_VERSION orientdb-community-1.7.4
+ENV ORIENT_VERSION orientdb-community-1.7.7
 RUN mkdir ${ROOT} \
     && cd ${ROOT} \
     && wget ${ORIENT_URL}/-/-/-/-/-/${ORIENT_VERSION}.tar.gz/false/false/linux \
     && tar -xzf linux \
     && ln -s ${ROOT}/${ORIENT_VERSION} ${ROOT}/orientdb
-    && ln -s ${ROOT}/orientdb/bin/* /usr/local/bin/
+    
+RUN ln -s ${ROOT}/orientdb/bin/* /usr/local/bin/
+RUN mkdir /usr/local/log
 
-# clenaup
+# cleanup
 RUN apt-get -y -qq --force-yes clean \
     && rm -rf /opt/downloads/linux /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
updated orientdb version to 1.7.7
fixed the 'missing /usr/local/bin/server.sh' error
fixed log folder lock error
